### PR TITLE
Add effective_severity field to vulnerability Detail. 

### DIFF
--- a/proto/v1beta1/vulnerability.proto
+++ b/proto/v1beta1/vulnerability.proto
@@ -155,6 +155,11 @@ message Details {
 
   // Output only. URLs related to this vulnerability.
   repeated grafeas.v1beta1.RelatedUrl related_urls = 7;
+
+  // The distro assigned severity for this vulnerability when it is
+  // available, and note provider assigned severity when distro has not yet
+  // assigned a severity for this vulnerability.
+  Severity effective_severity = 8;  
 }
 
 // This message wraps a location affected by a vulnerability and its
@@ -166,6 +171,7 @@ message PackageIssue {
   // The location of the available fix for vulnerability.
   VulnerabilityLocation fixed_location = 2;
 
+  // Deprecated, use Details.effective_severity instead
   // The severity (e.g., distro assigned severity) for this vulnerability.
   string severity_name = 3;
 }


### PR DESCRIPTION
This deprecates the use of the severity_name field inside Package Issue. 